### PR TITLE
RTSS-9 Add table fruit

### DIFF
--- a/src/main/resources/db/changelog/tables/address.yml
+++ b/src/main/resources/db/changelog/tables/address.yml
@@ -2,6 +2,11 @@ databaseChangeLog:
   - changeSet:
       id: '1'
       author: ezra
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          tableExists:
+            tableName: address
       changes:
         - createTable:
             tableName: address

--- a/src/main/resources/db/changelog/tables/fruit.yml
+++ b/src/main/resources/db/changelog/tables/fruit.yml
@@ -1,0 +1,55 @@
+databaseChangeLog:
+  - changeSet:
+      id: '1'
+      author: chumo
+      preConditions:
+        - not:
+            tableExists:
+              tableName: fruit
+      changes:
+        - createTable:
+            tableName: fruit
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+                    notNullConstraintName: fruit_name_notnull
+              - column:
+                  name: alternate_name
+                  type: varchar(255)
+              - column:
+                  name: color
+                  type: varchar(50)
+                  constraints:
+                    nullable: false
+                    notNullConstraintName: fruit_color_notnull
+              - column:
+                  name: cost
+                  type: decimal(10,2)
+                  constraints:
+                    nullable: false
+                    notNullConstraintName: fruit_cost_notnull
+              - column:
+                  name: edible_ind
+                  type: boolean
+                  constraints:
+                    nullable: false
+                    notNullConstraintName: fruit_edible_ind_notnull
+              - column:
+                  name: created_by_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    notNullConstraintName: fruit_created_by_id_notnull
+              - column:
+                  name: created_on
+                  type: timestamptz
+                  defaultValueDate: ${now}


### PR DESCRIPTION
**Changes**

- feat(schema): Add fruit table and improve migration safety
- Add a new fruit table with business and audit fields
- Add preConditions to prevent duplicate table creation
- Include a full table structure with proper constraints
- Set up standard audit fields (created_by_id, created_on)  

**Affects**
Modified the address.yml file to include a precondition that checks whether the table exists before attempting to create it

