### PR TITLE
RTSS-61-Add-mapper-for-the-the-created-entity-dto

### DIFF
--- a/src/main/kotlin/me/ezra_home/retail_software_solution/business/fruit/FruitMapper.kt
+++ b/src/main/kotlin/me/ezra_home/retail_software_solution/business/fruit/FruitMapper.kt
@@ -1,0 +1,27 @@
+package me.ezra_home.retail_software_solution.business.fruit
+
+import me.ezra_home.retail_software_solution.business.fruit.dto.FruitInsertDto
+import me.ezra_home.retail_software_solution.business.fruit.dto.FruitResponseDto
+import me.ezra_home.retail_software_solution.business.fruit.dto.FruitUpdateDto
+import me.ezra_home.retail_software_solution.business.util.mapper.RtsMapperConfig
+import me.ezra_home.retail_software_solution.model.entity.FruitEntity
+import org.mapstruct.BeanMapping
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import org.mapstruct.MappingTarget
+import org.mapstruct.NullValuePropertyMappingStrategy
+
+@Mapper(config = RtsMapperConfig::class)
+interface FruitMapper {
+    fun toDto(fruitEntity: FruitEntity): FruitResponseDto
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdById", ignore = true)
+    @Mapping(target = "createdOn", ignore = true)
+    fun toEntity(fruitInsertDto: FruitInsertDto): FruitEntity
+
+    @Mapping(target = "createdById", ignore = true)
+    @Mapping(target = "createdOn", ignore = true)
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    fun partialUpdate(fruitDto: FruitUpdateDto, @MappingTarget fruitEntity: FruitEntity)
+}


### PR DESCRIPTION
Implement automated entity-DTO conversions using MapStruct's powerful annotation processor. This reduces manual mapping code that can be error-prone and hard to maintain, while providing compile-time safety and better performance than reflection-based mapping solutions.