### PR TITLE
RTSS 106 Backend to support launching an organization

### DIFF
--- a/src/main/kotlin/me/ezra_home/retail_software_solution/platform/business/organization_join_request/dto/OrganizationAdminJoinRequestResponseDto.kt
+++ b/src/main/kotlin/me/ezra_home/retail_software_solution/platform/business/organization_join_request/dto/OrganizationAdminJoinRequestResponseDto.kt
@@ -3,8 +3,10 @@ package me.ezra_home.retail_software_solution.platform.business.organization_joi
 import me.ezra_home.retail_software_solution.util.enums.JoinRequestStatus
 import java.io.Serializable
 import java.time.OffsetDateTime
+import java.util.UUID
 
 data class OrganizationAdminJoinRequestResponseDto(
+    val id: UUID?,
     val fullName: String,
     val requestedDate: OffsetDateTime,
     val status: JoinRequestStatus

--- a/src/main/kotlin/me/ezra_home/retail_software_solution/platform/business/organization_join_request/dto/OrganizationJoinRequestResponseDto.kt
+++ b/src/main/kotlin/me/ezra_home/retail_software_solution/platform/business/organization_join_request/dto/OrganizationJoinRequestResponseDto.kt
@@ -3,8 +3,10 @@ package me.ezra_home.retail_software_solution.platform.business.organization_joi
 import me.ezra_home.retail_software_solution.util.enums.JoinRequestStatus
 import java.io.Serializable
 import java.time.OffsetDateTime
+import java.util.UUID
 
 data class OrganizationJoinRequestResponseDto(
+    val id: UUID?,
     val domain: String,
     val requestedDate: OffsetDateTime,
     val status: JoinRequestStatus


### PR DESCRIPTION
Added `id` field to `OrganizationAdminJoinRequestResponseDto` and `OrganizationJoinRequestResponseDto`
**Reason** :- The `id` is required by web frontend for its `store` to work correctly, otherwise only the last item in the list will be displayed in the UI